### PR TITLE
Adding Privacy and Terms and Conditions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Space Finder
-email: ""
+email: "dd547@cam.ac.uk"
 description: >-
   Spacefinder includes detailed descriptions of spaces,
   filters based on space characteristics, and navigation
@@ -23,8 +23,8 @@ dc:
     - "Digital mapping"
     - "College Campuses"
 terms:
-  url: ""
-  text: ""
+  url: "modal"
+  text: "Terms and Conditions"
   shorttext: ""
 foi:
   url: ""

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -5,11 +5,15 @@
             <li><button type="button" class="modal-trigger icon-universal-access button-icon" data-dialoghash="accessibility" data-dialogid="accessibility-page" aria-label="Accessibility page"><span class="button-text">Accessibility</span></button></li>
             <li><button type="button" class="modal-trigger" data-dialoghash="privacy" data-dialogid="privacy-page" aria-label="Privacy page">Privacy</button></li>
             {%- if site.terms.url != "" and site.terms.text != "" -%}
-                {%- if site.terms.shorttext != "" -%}
+                {%- if site.terms.url == "modal" -%}
+            <li><button type="button" class="modal-trigger" data-dialoghash="terms" data-dialogid="terms" aria-label="Terms and Conditions">Terms and Conditions</button></li>
+                {%- else if site.terms.shorttext != "" -%}
                     {%- capture termstext -%}<span class="hide-med">{{ site.terms.text }}</span><span class="show-med">{{ site.terms.shorttext }}</span>{%- endcapture -%}
                 {%- else -%}
                     {%- assign termstext = site.terms.text -%}
                 {%- endif -%}
+
+            {%- else if site.terms.url != "modal"-%}
             <li><a target="external" href="{{ site.terms.url }}">{{ termstext }}</a></li>
             {%- endif -%}
             {%- if site.foi.url != "" and site.foi.text != "" -%}

--- a/_includes/modal-includes.html
+++ b/_includes/modal-includes.html
@@ -37,6 +37,19 @@
     </article>
 </div>
 
+<div id="terms" class="dialog-container" aria-labelledby="terms-page-title" aria-describedby="terms-page-description" aria-hidden="true">
+    <div class="dialog-overlay" data-a11y-dialog-hide></div>
+    <article role="document" class="dialog-content">
+        <header>
+            <button type="button" class="button dialog-close" data-a11y-dialog-hide aria-label="Close dialog">&times;</button>
+            <h2 id="terms-page-title">Terms and Conditions</h2>
+            <p class="visuallyhidden" id="terms-page-description">Terms and Conditions for Spacefinder</p>
+        </header>
+        {% capture terms_page %}{% include pages/terms.md %}{% endcapture %}
+        {{ terms_page | markdownify }}
+    </article>
+</div>
+
 <div id="sfalertdialog" class="dialog-container" role="alertdialog" aria-labelledby="sfalertdialog-title" aria-describedby="sfalertdialog-description" aria-hidden="true">
     <div class="dialog-overlay"></div>
     <article role="document" class="dialog-content alert-dialog">

--- a/_includes/pages/privacy.md
+++ b/_includes/pages/privacy.md
@@ -1,1 +1,34 @@
-Privacy notice for {{ site.url }}{{ site.baseurl }}
+### General 
+This policy explains what information we gather when you visit the site, and explains how that information is used.
+
+It is important for you to appreciate that the site provides links to other independent sites, both within the University and elsewhere. This policy applies only to direct accesses to Spacefinder - URLs starting http://spacefinder.lib.cam.ac.uk/ You will need to consult the appropriate information on other sites for information on their policies.
+
+### Data collected
+In common with most websites, this site automatically logs certain information about every request made of it (see below for more details). This information is used for system administration, for bug tracking, for producing usage statistics, and for evaluating the usefulness of services offered. The logged information may be kept indefinitely.
+
+Relevant subsets of this data may be passed to computer security teams as part of investigations of computer misuse involving this site or other computing equipment in the University. Data may be passed to the administrators of other computer systems to enable investigation of problems accessing this site or of system misconfigurations. Data may incidentally be included in information passed to contractors and computer maintenance organisations working for the University, in which case it will be covered by appropriate non-disclosure agreements. Otherwise the logged information is not passed to any third party except if required by law. Summary statistics are extracted from this data and some of these may be made publicly available, but those that are do not include information from which individuals could be identified.
+
+You should appreciate that a log is a record of what a server sees, not necessarily what was initially sent. If a request is sent via a proxy the log file will show the proxy's address. If someone has forged your address the log file will show your address.
+
+This site may use web "cookies" as part of user authentication (login) and to store information needed by other facilities.
+
+### Logged data
+The following data is automatically logged for each request:
+
+- The name or network address of the computer making the request. Note that under some (but not all) circumstances it may be possible to infer from this the identity of the person making the request. Note also that the data recorded may be that of a web proxy rather than that of the originating client.
+- The username, when known during authenticated (logged in) access to the site
+- The date and time of connection
+- The HTTP request, which contains the identification of the space viewed
+- The status code of the request (success or failure etc.)
+- The number of data bytes sent in response
+- The contents of the HTTP Referrer header supplied by the browser
+- The content of the HTTP User-Agent header supplied by the browser.
+
+Via Raven authentication. We only log the information that you knowingly submit when contributing to the site via Raven. No hidden information is sent or stored.
+
+Logging of additional data may be enabled temporarily from time to time for specific purposes. In addition, the computers on which the site is hosted keep records of attempts (authorised and unauthorised) to use them for purposes other than access to the web server. This data typically includes the date and time of the attempt, the service to which access was attempted, the name or network address of the computer making the connection, and may include details of what was done or was attempted to be done.
+
+### Access to personal data 
+For the purpose of the UK Data Protection Act 1998, the "Data Controller" for the processing of data collected by this site is the University of Cambridge, and the point of contact for subject access requests is the University Data Protection Officer (10 Peas Hill, Cambridge, CB2 3PN, tel. 01223 339888, fax 01223 331200, email data.protection@admin.cam.ac.uk ).
+
+The University is also Data Controller in respect of any personal data served as content directly by this site.

--- a/_includes/pages/terms.md
+++ b/_includes/pages/terms.md
@@ -1,0 +1,161 @@
+The following are Terms and Conditions for the Spacefinder pilot web service agreed on 01 September 2015. It is anticipated that they may be revised later as per the 'Terms of website use' below.
+
+- <a href="#1">Terms of website use</a>
+- <a href="#2">Information about us</a>
+- <a href="#3">Accessibility</a>
+- <a href="#4">Information we collect (privacy policy)</a>
+- <a href="#5">Access to information (data protection policy)</a>
+- <a href="#6">Accessing our site</a>
+- <a href="#7">Notice and takedown policy</a>
+- <a href="#8">Making contributions to the site</a>
+- <a href="#9">Content standards</a>
+- <a href="#10">Limitation of liability</a>
+- <a href="#11">General</a>
+- <a href="#12">Jurisdiction</a>
+- <a href="#13">Contact details</a>
+
+## 1. Terms of website use <a id="1"></a>
+These terms of use (together with the documents referred to in them) set out the terms for use of the Spacefinder pilot website ('our/this/the site') and apply to all users of and visitors to the site ('you'). Please read these terms of use carefully before you begin to use the site. By using the site, you indicate that you accept these terms of use and that you agree to abide by them. If you do not agree to these terms of use, please refrain from accessing, using and/or contributing to the site.
+
+These terms of use may be amended at any time. Revised terms of use take effect immediately from the time they are published and continued use of the site will be deemed acceptance of updated or amended terms.
+
+## 2. Information about us <a id="2"></a>
+The site is operated by Cambridge University Library ('we','us' or the 'University'), whose postal address is Cambridge University Library, West Road, Cambridge, United Kingdom CB3 9DR. The registered address of the University is Cambridge, The Old Schools, Trinity Lane, Cambridge, United Kingdom CB2 1TN.
+
+## 3. Accessibility <a id="3"></a>
+Please see the [University of Cambridge Web Accessibility Policy](https://www.cam.ac.uk/web-support/university-of-cambridge-web-accessibility-policy).
+
+## 4. Information we collect (privacy policy) <a id="4"></a>
+<em>General.</em> This policy explains what information we gather when you visit the site, and explains how that information is used.
+
+It is important for you to appreciate that the site provides links to other independent sites, both within the University and elsewhere. This policy applies only to direct accesses to Spacefinder - URLs starting http://spacefinder.lib.cam.ac.uk/ You will need to consult the appropriate information on other sites for information on their policies.
+
+<em>Data collected.</em> In common with most websites, this site automatically logs certain information about every request made of it (see below for more details). This information is used for system administration, for bug tracking, for producing usage statistics, and for evaluating the usefulness of services offered. The logged information may be kept indefinitely.
+
+Relevant subsets of this data may be passed to computer security teams as part of investigations of computer misuse involving this site or other computing equipment in the University. Data may be passed to the administrators of other computer systems to enable investigation of problems accessing this site or of system misconfigurations. Data may incidentally be included in information passed to contractors and computer maintenance organisations working for the University, in which case it will be covered by appropriate non-disclosure agreements. Otherwise the logged information is not passed to any third party except if required by law. Summary statistics are extracted from this data and some of these may be made publicly available, but those that are do not include information from which individuals could be identified.
+
+You should appreciate that a log is a record of what a server sees, not necessarily what was initially sent. If a request is sent via a proxy the log file will show the proxy's address. If someone has forged your address the log file will show your address.
+
+This site may use web "cookies" as part of user authentication (login) and to store information needed by other facilities.
+
+<em>Logged data.</em> The following data is automatically logged for each request:
+
+- The name or network address of the computer making the request. Note that under some (but not all) circumstances it may be possible to infer from this the identity of the person making the request. Note also that the data recorded may be that of a web proxy rather than that of the originating client.
+- The username, when known during authenticated (logged in) access to the site
+- The date and time of connection
+- The HTTP request, which contains the identification of the space viewed
+- The status code of the request (success or failure etc.)
+- The number of data bytes sent in response
+- The contents of the HTTP Referrer header supplied by the browser
+- The content of the HTTP User-Agent header supplied by the browser.
+
+Via Raven authentication. We only log the information that you knowingly submit when contributing to the site via Raven. No hidden information is sent or stored.
+
+Logging of additional data may be enabled temporarily from time to time for specific purposes. In addition, the computers on which the site is hosted keep records of attempts (authorised and unauthorised) to use them for purposes other than access to the web server. This data typically includes the date and time of the attempt, the service to which access was attempted, the name or network address of the computer making the connection, and may include details of what was done or was attempted to be done.
+
+Access to personal data. For the purpose of the UK Data Protection Act 1998, the "Data Controller" for the processing of data collected by this site is the University of Cambridge, and the point of contact for subject access requests is the University Data Protection Officer (10 Peas Hill, Cambridge, CB2 3PN, tel. 01223 339888, fax 01223 331200, email data.protection@admin.cam.ac.uk ).
+
+The University is also Data Controller in respect of any personal data served as content directly by this site.
+
+## 5. Access to information (data protection policy) <a id="5"></a>
+Please see the <a href="www.admin.cam.ac.uk/univ/information/">University of Cambridge Information Compliance homepage.</a>
+
+## 6. Accessing our site <a id="6"></a>
+Access to the site is permitted on a temporary basis and the University reserves the right to withdraw or amend the services provided on the site without notice. The University will not be liable if for any reason the site is unavailable at any time or for any period.
+
+The University may restrict access to users to some parts of the site or to the entire site for technical, administrative or legal reasons.
+
+
+You are responsible for making all arrangements necessary for you to have access to the site. You are also responsible for ensuring that all persons who access the site through your internet connection are aware of these terms and that they comply with them.
+
+You may use the site only for lawful purposes. You must not use the site:
+
+
+- In any way that breaches any applicable local, national or international law or regulation
+- In any way that is unlawful or fraudulent or has any unlawful or fraudulent purpose or effect
+- For the purpose of harming or attempting to harm minors in any way
+- To send, knowingly receive, upload, download, use or re-use any material that does not comply with Content Standards (see below)
+- To transmit or procure the sending of any unsolicited or unauthorised advertising or promotional material or any other form of similar solicitation (spam)
+- To knowingly transmit any data, send or upload any material that contains viruses or any other computer code, programs or files designed to destroy, interrupt or limit the functionality of any computer, computer software or hardware or telecommunications equipment.
+
+Use of the site by staff and students of the University is also subject to the University's policies and guidelines for computer use at: [https://help.uis.cam.ac.uk/policies](https://help.uis.cam.ac.uk/policies)
+
+## 7. Notice and takedown policy <a id="7"></a>
+If you are a rights holder and are concerned that you have found material on our site for which you have not given permission or is not covered by an exception or exemption in national law, please contact us in writing at the contact details given the end of these terms stating the following:
+
+
+- Your contact details
+- The full bibliographical details of the material
+- The exact and full URL where you found the material
+- A statement and any proof you may provide that you are the rights holder or are an authorised representative thereof.
+
+Upon receipt of notification, Cambridge University Library will acknowledge receipt of your complaint by email or letter and will make an initial assessment of the validity of the complaint. Upon receipt of a valid complaint the material will be removed from the site pending an agreed solution.
+
+## 8. Making contributions to the site <a id="8"></a>
+In submitting a contribution to the site:
+
+You grant to the University a non-exclusive, worldwide, royalty-free licence to copy, reproduce, broadcast, transmit, display and perform by all means all or part of your contribution on the site for the entire period of copyright in your contribution and all renewals, extensions or revivals thereof; and
+
+Contributions or material submitted by University staff and students (and others as prescribed) is also subject to the Statutes and Ordinances of the University of Cambridge, specifically Ordinances, Chapter XIII Finance and Property, Intellectual Property Rights, pp. 982-990: [https://www.admin.cam.ac.uk/univ/so/pdfs/2020/nov2020/ordinance13.pdf](https://www.admin.cam.ac.uk/univ/so/pdfs/2020/nov2020/ordinance13.pdf).
+
+## 9. Content standards <a id="9"></a>
+These content standards apply to any and all material which you contribute to the site ('Contributions') and to any interactive services or features associated with it.
+
+Contributions must:
+
+
+- Be accurate (where they state facts)
+- Be genuinely held (where they state opinions)
+- Comply with applicable law in the UK and the law of the country from which they are posted.
+
+Contributions must not:
+
+- Contain any material that is likely to offend, provoke or attack other contributors to or users of the site
+- Contain any material that is defamatory of any person
+- Contain any material that is obscene, offensive, abusive or hateful
+- Promote sexually explicit material
+- Promote violence or contain a statement or describe or encourage activities that could endanger the safety or well-being of others
+- Promote discrimination of the basis of age, sex, sexual orientation, disability, race, religion, or nationality
+- Infringe any copyright, trademark or other intellectual property right of any person or organisation
+- Advocate, promote or assist any unlawful act or illegal activity
+- Be made in breach of any legal duty owed to a third party such as a contractual duty or a duty of confidence
+- Be threatening, harass, abuse or invade another's privacy or cause annoyance, inconvenience or needless anxiety to any person
+- Be used to impersonate any person or to misrepresent the contributor's identity or affiliation with any person or organisation
+- Contain any material that contains viruses or any other computer code, programs or files designed to destroy, interrupt or limit the functionality of any computer, computer software or hardware or telecommunications equipment.
+
+The University reserves the right to review, edit or remove without warning any contribution that in its sole discretion breaches these Content Standards and to take further action, including legal action, as the University reasonably feels necessary or is required by law. 
+
+Notwithstanding the foregoing, and to the fullest extent permitted by law, the University accepts no responsibility or liability to any third party for the content or accuracy of any material posted by any user of the site.
+
+## 10. Limitation of liability <a id="10"></a>
+The site and its Content and University Material is provided on an 'AS IS' and 'AS AVAILABLE' basis. To the extent permitted by law, the University excludes any representations or any warranties (whether express or implied by law), including the implied warranties of satisfactory quality, fitness of a particular purpose, non-infringement, compatibility, security and accuracy.
+
+The site may contain advice, opinions, statements or other information by various contributors. Reliance upon any such advice, opinion, statement or other information is at your risk and to the extent permitted by law the University disclaims all liability and responsibility arising from any reliance placed on such information by any user of the site or by anyone who may be informed of such information.
+
+Where the site contains links to other websites and resources provided by third parties, those links are provided for information only. The University has no control over the contents of those sites or resources and accepts no responsibility for them or for any loss or damage that may arise from your use of them.
+
+In no event shall the University be liable to any party for any of the following losses or damages (whether such losses be foreseen, foreseeable, known or otherwise): loss of data, loss of revenue or anticipated profits, loss of business, loss of opportunity, loss of goodwill or injury to reputation, loss suffered by third parties, any direct, indirect, special, incidental, or consequential loss or damages arising out of use of the site or reliance on any material or services provided in the site or accessed through it, whether or not amended by third parties and regardless of form of action.
+
+Nothing in these terms of use is intended to exclude the University's liability for death or personal injury caused by the University's proven negligence or fraudulent misrepresentation.
+
+## 11. General <a id="11"></a>
+Nothing in these terms of use is intended to nor shall it confer any benefit on a third party whether under the Contracts (Rights of Third Parties) Act 1999 or otherwise.
+
+The University's failure or delay to exercise or enforce any right in these terms of use does not waive the University's right to enforce that right.
+
+If any of these terms of use should be determined to be illegal, invalid or otherwise unenforceable by reason of the laws of any country in which these terms of use are intended to be effective, then to the extent and within that jurisdiction in which that term of use is illegal, invalid or unenforceable, it shall be severed and deleted from these terms of use and the remaining terms of use shall survive and remain in full force and effect and continue to be binding and enforceable.
+
+## 12. Jurisdiction <a id="12"></a>
+These terms of use and all questions of construction, interpretation, validity and performance under these terms including non-contractual disputes or claims shall be governed by English law and subject to the exclusive jurisdiction of the English courts.
+
+## 3. Contact details <a id="13"></a>
+
+FutureLib Project Manager<br />
+Cambridge University Library
+West Road<br />
+United Kingdom<br />
+CB3 9DR<br />
+Email: <a href="mailto:dd547@cam.ac.uk">dd547@cam.ac.uk</a>
+
+
+


### PR DESCRIPTION
This change updates the Privacy statement to the value currently on Spacefinder (although this will need reviewing) and adds a Terms and Conditions modal.  We *could* link to an external terms and conditions page just by editing the config, but as we don't have one that sits separately to the application I added a modal option.  We may want to re-think this.

On the T&Cs page I have updated the following:

"The following are temporary Terms and Conditions for the Spacefinder pilot web service agreed on 01 September 2015. It is anticipated that they may be revised later in 2015 as per the 'Terms of website use' below."

I've changed to
"The following are Terms and Conditions for the Spacefinder pilot web service agreed on 01 September 2015. It is anticipated that they may be revised later as per the 'Terms of website use' below."

http://www.cam.ac.uk/cs/policies 
to 
https://help.uis.cam.ac.uk/policies 

https://www.cam.ac.uk/site/accessibility.html
to
https://www.cam.ac.uk/web-support/university-of-cambridge-web-accessibility-policy

http://www.admin.cam.ac.uk/univ/so/pdfs/ordinance13.pdf
to
https://www.admin.cam.ac.uk/univ/so/pdfs/2020/nov2020/ordinance13.pdf

It will need proper revision though, at a later date.