### PR TITLE
Fix bug that was incorrectly displaying the campus map link when no p…

### DIFF
--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -69,7 +69,7 @@ function getAdditionalInfo( space ) {
     if ( space.url !== "" && space.url_text !== '' ) {
         spaceHTML += '<li class="icon-link"><a target="spaceurl" href="' + space.url + '">' + space.url_text + '</a></li>';
     }
-    if ( space.campusmap_url != '' ) {
+    if ( space.campusmap_url !== undefined && space.campusmap_url !== '') {
         let campusmap_ref = space.campusmap_ref !== '' ? ' (map reference ' + space.campusmap_ref + ')': '';
         spaceHTML += '<li class="icon-uol-logo-mark"><a target="campusmap" href="' + space.campusmap_url + '">View on the University campus map</a>' + campusmap_ref + '<li>';
     }


### PR DESCRIPTION
…roperty was set

A fix for incorrectly displaying the campus map link when the "space.campusmap_url" variable was not set.
If we want to add this for a space add this variable, which we may want to do in bulk to the data at a later point.