### PR TITLE
Limit list sort in admin interface to title and modification date

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -27,6 +27,7 @@ collections:
 #    view_groups:
 #      - label: 'Type'
 #        field: 'space_type'
+    sortable_fields: ['title', 'commit_date']
     fields:
 #      - label: 'Published'
 #        name: 'published'


### PR DESCRIPTION
I noticed that the admin interface was automatically supplying four sort options (title, date, author and description) and it automagically attempted to determine which fields (or bits of data) belonged to each of those categories.  Rather than rely on unspoken defaults, I stipulated the sort fields as 'title' and 'date' (specifically, the date of the file's last commit). Commit author and commit description likely aren't that useful for us.