### PR TITLE
Indent json using two rather than four spaces

### DIFF
--- a/_scripts/processJSON.js
+++ b/_scripts/processJSON.js
@@ -5,29 +5,30 @@ const fs = require('fs');
 const path = require('path');
 
 /* get a list of files from the spaces directory */
-const spacefiles = fs.readdirSync( path.resolve( __dirname, '../spaces' ), { encoding: 'utf8' } );
+const spacefiles = fs.readdirSync( path.resolve( __dirname, '../spaces' ), { encoding: 'utf8' } )
+    .filter(file => {
+        return path.extname(file).toLowerCase() === '.json';
+    });
 /* loop through the files */
 spacefiles.forEach( filename => {
-    if ( filename !== '.' && filename !== '..' ) {
-        /* read file */
-        let spaceData = fs.readFileSync( path.resolve( __dirname, '../spaces/', filename ) );
-        /* parse file contents */
-        const spaceJSON = JSON.parse( spaceData );
-        /* parse GeoJSON string in location */
-        let geoJSON = JSON.parse( spaceJSON.location );
+    /* read file */
+    let spaceData = fs.readFileSync(path.resolve(__dirname, '../spaces/', filename));
+    /* parse file contents */
+    const spaceJSON = JSON.parse(spaceData);
+    /* parse GeoJSON string in location */
+    let geoJSON = JSON.parse(spaceJSON.location);
 
-        /*--------------*/
-        /* process data */
-        /*--------------*/
+    /*--------------*/
+    /* process data */
+    /*--------------*/
 
-        /* write results to file */
-        fs.writeFile( path.resolve( __dirname, '../spaces/'+spaceJSON.id+'.json' ), JSON.stringify( spaceJSON, null, '    ' ), err => {
-            if (err) {
-                console.error( err );
-                return;
-            }
-        });
-    }
+    /* write results to file */
+    fs.writeFile(path.resolve(__dirname, '../spaces/' + spaceJSON.id + '.json'), JSON.stringify(spaceJSON, null, 2), err => {
+        if (err) {
+            console.error(err);
+            return;
+        }
+    });
 });
 
 /**


### PR DESCRIPTION
The main changes in this PR was to set the json indentation value to 2.

I also added a filter to onto readdirSync so that it only gets json files. This allows us to get rid of a conditional when we loop through the files later on.  This change necessitated a reformat in the code, so the default view of the diff will make it hard to see the significant changes. I'd recommend checking out the new branch and running `git diff --color-words='.' --ignore-space-change HEAD^! `.